### PR TITLE
ユーザー追加API実装、エラー処理の修正、ロガー機能実装

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,3 +16,4 @@ diesel = {version ="1.4.0", features = ["sqlite", "r2d2"] }
 dotenv = "0.9.0"
 r2d2 = "0.8"
 serde_repr = "0.1.6"
+env_logger = "0.8.3"

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -5,7 +5,10 @@ use super::person::*;
 use super::db::DbPool;
 
 pub async fn attend(pool: web::Data<DbPool>, info: web::Path<(i32,)>) -> Result<HttpResponse> {
-    let connection = pool.get().expect("couldn't get db connection from pool");
+    let connection = pool.get().map_err(|e| {
+        eprintln!("{}", e);
+        HttpResponse::InternalServerError().finish()
+    })?;
     let input: i32 = info.0;
     let result =
         web::block(move || super::db::update_user_status(input, State::Attend, &connection))
@@ -23,7 +26,10 @@ pub async fn attend(pool: web::Data<DbPool>, info: web::Path<(i32,)>) -> Result<
 }
 
 pub async fn leave(pool: web::Data<DbPool>, info: web::Path<(i32,)>) -> Result<HttpResponse> {
-    let connection = pool.get().expect("couldn't get db connection from pool");
+    let connection = pool.get().map_err(|e| {
+        eprintln!("{}", e);
+        HttpResponse::InternalServerError().finish()
+    })?;
     let input: i32 = info.0;
     let result =
         web::block(move || super::db::update_user_status(input, State::Leave, &connection))
@@ -41,7 +47,10 @@ pub async fn leave(pool: web::Data<DbPool>, info: web::Path<(i32,)>) -> Result<H
 }
 
 pub async fn get_all(pool: web::Data<DbPool>) -> Result<HttpResponse> {
-    let connection = pool.get().expect("couldn't get db connection from pool");
+    let connection = pool.get().map_err(|e| {
+        eprintln!("{}", e);
+        HttpResponse::InternalServerError().finish()
+    })?;
     let ret = web::block(move || super::db::list_users(&connection))
         .await
         .map_err(|e| {
@@ -52,7 +61,10 @@ pub async fn get_all(pool: web::Data<DbPool>) -> Result<HttpResponse> {
 }
 
 pub async fn get_student(pool: web::Data<DbPool>, info: web::Path<(i32,)>) -> Result<HttpResponse> {
-    let connection = pool.get().expect("couldn't get db connection from pool");
+    let connection = pool.get().map_err(|e| {
+        eprintln!("{}", e);
+        HttpResponse::InternalServerError().finish()
+    })?;
     let input: i32 = info.0;
     let person = web::block(move || super::db::find_user_by_id(input, &connection))
         .await
@@ -69,12 +81,18 @@ pub async fn get_student(pool: web::Data<DbPool>, info: web::Path<(i32,)>) -> Re
     }
 }
 
-//pub async fn signup<'a>(info: web::Json<NewPerson<'a>>) -> Result<HttpResponse> {
-//    use super::schema::people;
-//    let connection = super::db::establish_connection();
-//    diesel::insert_into(people::table)
-//        .values(&*info)
-//        .execute(connection)
-//        .expect("Error signup");
-//    Ok(HttpResponse::Ok())
-//}
+pub async fn register(pool: web::Data<DbPool>, info: web::Json<NewPerson>) -> Result<HttpResponse> {
+    let connection = pool.get().map_err(|e| {
+        eprintln!("{}", e);
+        HttpResponse::InternalServerError().finish()
+    })?;
+
+    web::block(move || super::db::register_user(&connection, &info))
+        .await
+        .map_err(|e| {
+            eprintln!("{}", e);
+            HttpResponse::InternalServerError().finish()
+        })?;
+
+    Ok(HttpResponse::Ok().finish())
+}

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -53,22 +53,13 @@ pub fn find_user_by_id(
     Ok(ret)
 }
 
-pub fn create_post<'a>(
+pub fn register_user(
     conn: &SqliteConnection,
-    username: &'a str,
-    role: &'a str,
-    roomid: Option<i32>,
-) -> usize {
+    new_person: &NewPerson,
+) -> Result<usize, diesel::result::Error> {
     use super::schema::people;
 
-    let new_person = NewPerson {
-        username,
-        role,
-        roomid,
-    };
-
     diesel::insert_into(people::table)
-        .values(&new_person)
+        .values(new_person)
         .execute(conn)
-        .expect("Error")
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,6 +2,7 @@
 extern crate diesel;
 extern crate dotenv;
 
+use actix_web::middleware::Logger;
 use actix_web::web;
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager};
@@ -28,12 +29,13 @@ async fn main() -> std::io::Result<()> {
     let mut listenfd = ListenFd::from_env();
     let mut server = HttpServer::new(move || {
         App::new()
+            .wrap(Logger::default())
             .data(pool.clone())
             .route("/api/attend/{id}", web::put().to(api::attend))
             .route("/api/leave/{id}", web::put().to(api::leave))
             .route("/api/students", web::get().to(api::get_all))
             .route("/api/student/{id}", web::get().to(api::get_student))
-            .route("/api/signup/", web::post().to(api::register))
+            .route("/api/register", web::post().to(api::register))
     });
 
     server = if let Some(l) = listenfd.take_tcp_listener(0).unwrap() {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,14 +3,14 @@ extern crate diesel;
 extern crate dotenv;
 
 use actix_web::web;
-use listenfd::ListenFd;
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager};
+use listenfd::ListenFd;
 
 pub mod api;
+pub mod db;
 pub mod person;
 pub mod schema;
-pub mod db;
 
 #[actix_rt::main]
 async fn main() -> std::io::Result<()> {
@@ -23,16 +23,15 @@ async fn main() -> std::io::Result<()> {
         .build(manager)
         .expect("Failed to create pool.");
 
-
     let mut listenfd = ListenFd::from_env();
-    let mut server =  HttpServer::new(move || {
+    let mut server = HttpServer::new(move || {
         App::new()
             .data(pool.clone())
             .route("/api/attend/{id}", web::put().to(api::attend))
             .route("/api/leave/{id}", web::put().to(api::leave))
             .route("/api/students", web::get().to(api::get_all))
             .route("/api/student/{id}", web::get().to(api::get_student))
-            //.route("/api/signup/", web::post().to(api::signup))
+            .route("/api/signup/", web::post().to(api::register))
     });
 
     server = if let Some(l) = listenfd.take_tcp_listener(0).unwrap() {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,6 +5,7 @@ extern crate dotenv;
 use actix_web::web;
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager};
+use env_logger;
 use listenfd::ListenFd;
 
 pub mod api;
@@ -16,6 +17,7 @@ pub mod schema;
 async fn main() -> std::io::Result<()> {
     use actix_web::{App, HttpServer};
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let connspec = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let manager = ConnectionManager::<SqliteConnection>::new(connspec);

--- a/server/src/person.rs
+++ b/server/src/person.rs
@@ -6,9 +6,9 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Insertable, Deserialize)]
 #[table_name = "people"]
-pub struct NewPerson<'a> {
-    pub username: &'a str,
-    pub role: &'a str,
+pub struct NewPerson {
+    pub username: String,
+    pub role: String,
     pub roomid: Option<i32>,
 }
 


### PR DESCRIPTION
register APIを追加、POSTメソッドでjsonでデータを送信することで、DBに追加する。
各APIにおいて、DBのコネクションプールのエラーを握り潰さないようにした。
ミドルウェアでロガーを追加した。環境変数`RUST_LOG`でレベルを設定可能（`trace`、`info`など）